### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -26,6 +26,10 @@ on:
   schedule:
     - cron: '17 4 * * 0'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   MSDO:
     # currently only windows latest is supported


### PR DESCRIPTION
Potential fix for [https://github.com/Amanv1211/screenshare-webrtc/security/code-scanning/8](https://github.com/Amanv1211/screenshare-webrtc/security/code-scanning/8)

Add an explicit `permissions` block to the workflow so token scopes are least-privilege and documented.

Best fix here (without changing intended functionality): define workflow-level permissions with:
- `contents: read` (minimum for checkout),
- `security-events: write` (required to upload SARIF to the Security tab).

Edit `.github/workflows/defender-for-devops.yml` near the top-level keys, directly after the trigger block (`on:`...) and before `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
